### PR TITLE
Fix a missing include in read_points.hpp

### DIFF
--- a/include/small_gicp/benchmark/read_points.hpp
+++ b/include/small_gicp/benchmark/read_points.hpp
@@ -4,6 +4,7 @@
 
 #include <fstream>
 #include <iostream>
+#include <vector>
 #include <Eigen/Core>
 
 namespace small_gicp {


### PR DESCRIPTION
Fixes a compilation error on Clang 13 / libc++.