### PR TITLE
Auto download eigen

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -1,4 +1,4 @@
-name: Build
+name: Build(Linux)
 
 on:
   push:

--- a/.github/workflows/build-windows.yml
+++ b/.github/workflows/build-windows.yml
@@ -20,10 +20,6 @@ jobs:
 
       - uses: microsoft/setup-msbuild@v2
 
-      - uses: crazy-max/ghaction-chocolatey@v3
-        with:
-          args: install cmake eigen
-
       - uses: actions/setup-python@v5
         with:
           python-version: '3.12'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,20 @@ if(BUILD_TESTS OR BUILD_EXAMPLES)
 endif()
 
 # Eigen is the sole mandatory dependency
-find_package(Eigen3 REQUIRED CONFIG)
+find_package(Eigen3)
+
+if(NOT EIGEN3_FOUND)
+  message(STATUS "System Eigen not found. Download Eigen 3.3.9.")
+  include(FetchContent)
+  FetchContent_Populate(
+    Eigen3
+    URL https://gitlab.com/libeigen/eigen/-/archive/3.3.9/eigen-3.3.9.tar.gz
+  )
+  add_library(Eigen3::Eigen INTERFACE IMPORTED GLOBAL)
+  set_target_properties(Eigen3::Eigen PROPERTIES
+    INTERFACE_INCLUDE_DIRECTORIES "${CMAKE_BINARY_DIR}/Eigen3-src"
+  )
+endif()
 
 if(BUILD_WITH_OPENMP STREQUAL "auto")
   find_package(OpenMP)


### PR DESCRIPTION
To make it possible to install the package with pip on windows, download eigen when failed to find a system installed one.