### PR TITLE
Fix Eigen CMake variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,9 +40,9 @@ if(BUILD_TESTS OR BUILD_EXAMPLES)
 endif()
 
 # Eigen is the sole mandatory dependency
-find_package(Eigen3)
+find_package(Eigen3 CONFIG)
 
-if(NOT EIGEN3_FOUND)
+if(NOT Eigen3_FOUND)
   message(STATUS "System Eigen not found. Download Eigen 3.3.9.")
   include(FetchContent)
   FetchContent_Populate(


### PR DESCRIPTION
The upper-case `EIGEN3_FOUND` variable is available on v3.3.x, but has been removed in newer Eigen versions.

Since Eigen is always packaged with an `Eigen3Config.cmake` and CMake sets `<PackageName>_FOUND` automatically for `CONFIG`-type packages, `Eigen3_FOUND` should be used instead. From CMake docs:

> A set of variables which provide package status information are also set automatically when using a config-file package. The `<PackageName>_FOUND` variable is set to true or false, depending on whether the package was found.

On an unrelated note - is there a reason why the automatically downloaded Eigen is v3.3.9 instead of v3.4.0?