### PR TITLE
Fix BUILD_WITH_OPENMP being set to an incorrect value by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(BUILD_PYTHON_BINDINGS "Build python bindings" OFF)
 option(ENABLE_COVERAGE "Enable coverage" OFF)
 
 # Dependency options
-set(BUILD_WITH_OPENMP CACHE STRING "Build with OpenMP" "auto")
+set(BUILD_WITH_OPENMP "auto" CACHE STRING "Build with OpenMP")
 option(BUILD_WITH_TBB "Build with TBB" OFF)
 option(BUILD_WITH_PCL "Build with PCL (required for benchmark and test only)" OFF)
 option(BUILD_WITH_FAST_GICP "Build with fast_gicp (required for benchmark and test only)" OFF)


### PR DESCRIPTION
It gets currently set to `CACHE;STRING;Build with OpenMP;auto` due to a bug in one of my previous PRs. Sorry about that.

I tested it with `-DCMAKE_DISABLE_FIND_PACKAGE_OpenMP=ON` and it works as expected now.