### PR TITLE
Fix Doxygen parameter names that do not match the declarations

### DIFF
--- a/include/small_gicp/ann/flat_container.hpp
+++ b/include/small_gicp/ann/flat_container.hpp
@@ -78,8 +78,8 @@ public:
   /// @brief Find k nearest neighbors.
   /// @param pt           Query point
   /// @param k            Number of neighbors
-  /// @param k_index      Indices of nearest neighbors
-  /// @param k_sq_dist    Squared distances to nearest neighbors (sorted in ascending order)
+  /// @param k_indices    Indices of nearest neighbors
+  /// @param k_sq_dists   Squared distances to nearest neighbors (sorted in ascending order)
   /// @return             Number of found points
   size_t knn_search(const Eigen::Vector4d& pt, int k, size_t* k_indices, double* k_sq_dists) const {
     if (points.empty()) {
@@ -91,12 +91,9 @@ public:
     return result.num_found();
   }
 
-  /// @brief Find k nearest neighbors.
+  /// @brief Find k nearest neighbors and push them into the given result.
   /// @param pt           Query point
-  /// @param k            Number of neighbors
-  /// @param k_index      Indices of nearest neighbors
-  /// @param k_sq_dist    Squared distances to nearest neighbors (sorted in ascending order)
-  /// @return             Number of found points
+  /// @param result       Result collector that receives the candidates
   template <typename Result>
   void knn_search(const Eigen::Vector4d& pt, Result& result) const {
     if (points.empty()) {

--- a/include/small_gicp/ann/kdtree.hpp
+++ b/include/small_gicp/ann/kdtree.hpp
@@ -251,13 +251,12 @@ public:
   explicit KdTree(std::shared_ptr<const PointCloud> points, const Builder& builder = Builder()) : points(points),
                                                                                                   kdtree(*points, builder) {}
 
-  /// @brief  Find k-nearest neighbors. This method uses dynamic memory allocation.
+  /// @brief  Find the nearest neighbor.
   /// @param  query       Query point
-  /// @param  k           Number of neighbors
-  /// @param  k_indices   Indices of neighbors
-  /// @param  k_sq_dists  Squared distances to neighbors (sorted in ascending order)
+  /// @param  k_indices   Index of the nearest neighbor (uninitialized if not found)
+  /// @param  k_sq_dists  Squared distance to the nearest neighbor (uninitialized if not found)
   /// @param  setting     KNN search setting
-  /// @return             Number of found neighbors
+  /// @return             Number of found neighbors (0 or 1)
   size_t nearest_neighbor_search(const Eigen::Vector4d& query, size_t* k_indices, double* k_sq_dists, const KnnSetting& setting = KnnSetting()) const {
     return kdtree.nearest_neighbor_search(query, k_indices, k_sq_dists, setting);
   }

--- a/include/small_gicp/ann/projective_search.hpp
+++ b/include/small_gicp/ann/projective_search.hpp
@@ -156,13 +156,12 @@ public:
 
   explicit ProjectiveSearch(int width, int height, std::shared_ptr<const PointCloud> points) : points(points), search(width, height, *points) {}
 
-  /// @brief  Find k-nearest neighbors. This method uses dynamic memory allocation.
+  /// @brief  Find the nearest neighbor.
   /// @param  query       Query point
-  /// @param  k           Number of neighbors
-  /// @param  k_indices   Indices of neighbors
-  /// @param  k_sq_dists  Squared distances to neighbors (sorted in ascending order)
+  /// @param  k_indices   Index of the nearest neighbor (uninitialized if not found)
+  /// @param  k_sq_dists  Squared distance to the nearest neighbor (uninitialized if not found)
   /// @param  setting     KNN search setting
-  /// @return             Number of found neighbors
+  /// @return             Number of found neighbors (0 or 1)
   size_t nearest_neighbor_search(const Eigen::Vector4d& query, size_t* k_indices, double* k_sq_dists, const KnnSetting& setting = KnnSetting()) const {
     return search.nearest_neighbor_search(query, k_indices, k_sq_dists, setting);
   }


### PR DESCRIPTION
Four Doxygen blocks describe something other than the function under them. Comments only.

**`KdTree::nearest_neighbor_search` and `ProjectiveSearch::nearest_neighbor_search`** carry the doc block of `knn_search`:

```
/// @brief  Find k-nearest neighbors. This method uses dynamic memory allocation.
/// @param  query       Query point
/// @param  k           Number of neighbors      <-- not a parameter
/// @param  k_indices   Indices of neighbors
/// @param  k_sq_dists  Squared distances to neighbors (sorted in ascending order)
/// @param  setting     KNN search setting
/// @return             Number of found neighbors
size_t nearest_neighbor_search(const Eigen::Vector4d& query, size_t* k_indices, double* k_sq_dists, const KnnSetting& setting = KnnSetting()) const
```

There is no `k`, the function returns at most one neighbor rather than k, and it does not allocate — it forwards straight to the unsafe variant. `UnsafeKdTree::nearest_neighbor_search`, a hundred lines above in the same file, documents the same thing correctly, so I took its wording rather than invent any:

```
/// @brief Find the nearest neighbor.
/// @param query        Query point
/// @param k_indices    Index of the nearest neighbor (uninitialized if not found)
/// @param k_sq_dists   Squared distance to the nearest neighbor (uninitialized if not found)
/// @param setting      KNN search setting
/// @return             Number of found neighbors (0 or 1)
```

**`FlatContainer::knn_search(pt, k, k_indices, k_sq_dists)`** documents `k_index` and `k_sq_dist` in the singular; the parameters are plural.

**The `Result` overload, `FlatContainer::knn_search(pt, result)`**, has the same block copied onto it, so it documents `k`, `k_index` and `k_sq_dist` — none of which exist — and says nothing about `result`. Rewritten to describe the two parameters it actually has.

Found by comparing every `@param` and `@tparam` name in the headers against the declaration below it.
